### PR TITLE
Improve link for cleanlab

### DIFF
--- a/data-cleaning.md
+++ b/data-cleaning.md
@@ -44,4 +44,5 @@ This line of work is closely related to the area of query explanations (e.g., [W
 * Data Standardization: 
   * [DataPrep.Clean](https://docs.dataprep.ai/user_guide/clean/introduction.html)
   * [Great Expectations](https://greatexpectations.io/)
-* [Label Clean](https://pypi.org/project/cleanlab/)
+* Label clean:
+  * [Cleanlab](https://docs.cleanlab.ai/v1.0.1/index.html)


### PR DESCRIPTION
Reasons for the update:

* It’s useful putting the name of the module to easily identify the resource.

* In the tools section, we are using DataPrep docs for reference. I think it would be better to link the documentation for cleanlab too.

* Another potential modification that I didn't do:  changing "Label clean" to "Label cleaning"